### PR TITLE
Updated to work with nim 0.20

### DIFF
--- a/godot/core/aabb.nim
+++ b/godot/core/aabb.nim
@@ -3,7 +3,7 @@
 import hashes
 
 import vector3
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 proc initAABB*(pos, size: Vector3): AABB {.inline.} =

--- a/godot/core/arrays.nim
+++ b/godot/core/arrays.nim
@@ -1,7 +1,7 @@
 # Copyright 2018 Xored Software, Inc.
 
 import hashes
-import internal.godotinternaltypes, internal.godotarrays
+import internal/godotinternaltypes, internal/godotarrays
 
 type
   Array* = ref object

--- a/godot/core/dictionaries.nim
+++ b/godot/core/dictionaries.nim
@@ -1,8 +1,8 @@
 # Copyright 2018 Xored Software, Inc.
 
 import hashes
-import internal.godotinternaltypes, internal.godotdictionaries,
-       internal.godotvariants, internal.godotstrings
+import internal/godotinternaltypes, internal/godotdictionaries,
+       internal/godotvariants, internal/godotstrings
 
 type
   Dictionary* = ref object

--- a/godot/core/nodepaths.nim
+++ b/godot/core/nodepaths.nim
@@ -2,8 +2,8 @@
 
 import hashes
 
-import internal.godotinternaltypes, internal.godotnodepaths,
-       internal.godotstrings
+import internal/godotinternaltypes, internal/godotnodepaths,
+       internal/godotstrings
 
 type
   NodePath* = ref object

--- a/godot/core/planes.nim
+++ b/godot/core/planes.nim
@@ -4,7 +4,7 @@ import hashes
 
 import vector3
 
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 proc initPlane*(a, b, c, d: float32): Plane {.inline.} =

--- a/godot/core/poolarrays.nim
+++ b/godot/core/poolarrays.nim
@@ -3,8 +3,8 @@
 import hashes
 
 import godotcoretypes
-import internal.godotinternaltypes, internal.godotpoolarrays,
-       internal.godotstrings
+import internal/godotinternaltypes, internal/godotpoolarrays,
+       internal/godotstrings
 import vector2, vector3, colors
 
 template definePoolArrayBase(T, GodotT, DataT, fieldName, newProcName,

--- a/godot/core/quats.nim
+++ b/godot/core/quats.nim
@@ -2,7 +2,7 @@
 
 import hashes
 
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 proc initQuat*(x, y, z, w: float32): Quat {.inline.} =

--- a/godot/core/rect2.nim
+++ b/godot/core/rect2.nim
@@ -3,7 +3,7 @@
 import hashes
 
 import vector2
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 {.push stackTrace: off.}

--- a/godot/core/rids.nim
+++ b/godot/core/rids.nim
@@ -2,7 +2,7 @@
 
 import hashes
 
-import godotcoretypes, internal.godotinternaltypes, gdnativeapi
+import godotcoretypes, internal/godotinternaltypes, gdnativeapi
 
 proc initRID*(): RID {.inline.} =
   getGDNativeAPI().ridNew(result)

--- a/godot/core/transform2d.nim
+++ b/godot/core/transform2d.nim
@@ -2,7 +2,7 @@
 
 import hashes, vector2
 
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 proc initTransform2D*(): Transform2D {.inline.} =

--- a/godot/core/transforms.nim
+++ b/godot/core/transforms.nim
@@ -2,7 +2,7 @@
 
 import hashes
 
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 import basis, vector3
 

--- a/godot/core/variants.nim
+++ b/godot/core/variants.nim
@@ -1,9 +1,9 @@
 import tables, hashes
 
 import godotcoretypes
-import internal.godotinternaltypes, internal.godotvariants,
-       internal.godotstrings, internal.godotdictionaries,
-       internal.godotarrays
+import internal/godotinternaltypes, internal/godotvariants,
+       internal/godotstrings, internal/godotdictionaries,
+       internal/godotarrays
 
 type
   Variant* = ref object

--- a/godot/core/vector2.nim
+++ b/godot/core/vector2.nim
@@ -2,7 +2,7 @@
 
 import math, godotbase, hashes
 
-import internal.godotinternaltypes, internal.godotstrings
+import internal/godotinternaltypes, internal/godotstrings
 import godotcoretypes, gdnativeapi
 
 {.push stackTrace: off.}

--- a/godot/gdnativeapi.nim
+++ b/godot/gdnativeapi.nim
@@ -1,6 +1,6 @@
 # Copyright 2018 Xored Software, Inc.
 
-import internal.godotinternaltypes, core.godotcoretypes, macros
+import internal/godotinternaltypes, core/godotcoretypes, macros
 
 type
   ColorData* {.byref.} = object

--- a/godot/gdnativeapi.nim
+++ b/godot/gdnativeapi.nim
@@ -3593,7 +3593,7 @@ proc setGDNativeAPIInternal(apiStruct: pointer, initOptions: ptr GDNativeInitOpt
       # Not used
       discard
 
-  if not header.next.isNil:
+  if not header.next.isNil and header != header.next:
     setGDNativeAPIInternal(header.next, initOptions,
                            foundCoreApi, foundNativeScriptApi)
 

--- a/godot/godot.nim
+++ b/godot/godot.nim
@@ -1,14 +1,14 @@
 # Copyright 2018 Xored Software, Inc.
 
-import core.godotbase, godotinternal
-import core.godotcoretypes
-import core.vector2, core.rect2, core.vector3, core.transform2d, core.planes,
-       core.quats
-import core.aabb, core.basis, core.transforms, core.colors, core.nodepaths,
-       core.rids
-import core.dictionaries, core.arrays, core.poolarrays, core.variants
+import core/godotbase, godotinternal
+import core/godotcoretypes
+import core/vector2, core/rect2, core/vector3, core/transform2d, core/planes,
+       core/quats
+import core/aabb, core/basis, core/transforms, core/colors, core/nodepaths,
+       core/rids
+import core/dictionaries, core/arrays, core/poolarrays, core/variants
 
-import nim.godotmacros, nim.godotnim
+import nim/godotmacros, nim/godotnim
 
 export godotbase, godotcoretypes, vector2, rect2, vector3, transform2d, planes,
        quats, aabb, basis, transforms, colors, nodepaths, rids, dictionaries,

--- a/godot/godotinternal.nim
+++ b/godot/godotinternal.nim
@@ -1,8 +1,8 @@
 # Copyright 2018 Xored Software, Inc.
 
-import internal.godotinternaltypes, internal.godotarrays,
-       internal.godotnodepaths, internal.godotpoolarrays, internal.godotstrings,
-       internal.godotvariants, internal.godotdictionaries
+import internal/godotinternaltypes, internal/godotarrays,
+       internal/godotnodepaths, internal/godotpoolarrays, internal/godotstrings,
+       internal/godotvariants, internal/godotdictionaries
 
 import gdnativeapi
 export godotinternaltypes, godotarrays, godotnodepaths, godotpoolarrays,

--- a/godot/internal/godotarrays.nim
+++ b/godot/internal/godotarrays.nim
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Xored Software, Inc.
 
-import godotinternaltypes, gdnativeapi, core.godotcoretypes
+import godotinternaltypes, gdnativeapi, core/godotcoretypes
 
 proc len*(self: GodotArray): cint {.inline.} =
   getGDNativeAPI().arraySize(self)

--- a/godot/internal/godotpoolarrays.nim
+++ b/godot/internal/godotpoolarrays.nim
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Xored Software, Inc.
 
 import godotinternaltypes, gdnativeapi
-import core.godotcoretypes
+import core/godotcoretypes
 
 template genPoolArrayAPI(ArrayT, initIdent, DataT,
                          newProc, newCopyProc, newWithArrayProc, appendProc,

--- a/godot/internal/godotvariants.nim
+++ b/godot/internal/godotvariants.nim
@@ -1,6 +1,6 @@
 # Copyright 2018 Xored Software, Inc.
 
-import core.godotcoretypes, godotinternaltypes, gdnativeapi
+import core/godotcoretypes, godotinternaltypes, gdnativeapi
 
 proc getType*(p: GodotVariant): VariantType {.inline.} =
   getGDNativeAPI().variantGetType(p)

--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -432,35 +432,6 @@ proc toGodotStyle(s: string): string {.compileTime.} =
     else:
       result.add(c)
 
-      # nnkNone, nnkEmpty, nnkIdent, nnkSym, nnkType, nnkCharLit, nnkIntLit, nnkInt8Lit,
-      # nnkInt16Lit, nnkInt32Lit, nnkInt64Lit, nnkUIntLit, nnkUInt8Lit, nnkUInt16Lit,
-      # nnkUInt32Lit, nnkUInt64Lit, nnkFloatLit, nnkFloat32Lit, nnkFloat64Lit,
-      # nnkFloat128Lit, nnkStrLit, nnkRStrLit, nnkTripleStrLit, nnkNilLit, nnkComesFrom,
-      # nnkDotCall, nnkCommand, nnkCall, nnkCallStrLit, nnkInfix, nnkPrefix, nnkPostfix,
-      # nnkHiddenCallConv, nnkExprEqExpr, nnkExprColonExpr, nnkIdentDefs, nnkVarTuple,
-      # nnkPar, nnkObjConstr, nnkCurly, nnkCurlyExpr, nnkBracket, nnkBracketExpr,
-      # nnkPragmaExpr, nnkRange, nnkDotExpr, nnkCheckedFieldExpr, nnkDerefExpr, nnkIfExpr,
-      # nnkElifExpr, nnkElseExpr, nnkLambda, nnkDo, nnkAccQuoted, nnkTableConstr, nnkBind,
-      # nnkClosedSymChoice, nnkOpenSymChoice, nnkHiddenStdConv, nnkHiddenSubConv, nnkConv,
-      # nnkCast, nnkStaticExpr, nnkAddr, nnkHiddenAddr, nnkHiddenDeref, nnkObjDownConv,
-      # nnkObjUpConv, nnkChckRangeF, nnkChckRange64, nnkChckRange, nnkStringToCString,
-      # nnkCStringToString, nnkAsgn, nnkFastAsgn, nnkGenericParams, nnkFormalParams,
-      # nnkOfInherit, nnkImportAs, nnkProcDef, nnkMethodDef, nnkConverterDef, nnkMacroDef,
-      # nnkTemplateDef, nnkIteratorDef, nnkOfBranch, nnkElifBranch, nnkExceptBranch,
-      # nnkElse, nnkAsmStmt, nnkPragma, nnkPragmaBlock, nnkIfStmt, nnkWhenStmt, nnkForStmt,
-      # nnkParForStmt, nnkWhileStmt, nnkCaseStmt, nnkTypeSection, nnkVarSection,
-      # nnkLetSection, nnkConstSection, nnkConstDef, nnkTypeDef, nnkYieldStmt, nnkDefer,
-      # nnkTryStmt, nnkFinally, nnkRaiseStmt, nnkReturnStmt, nnkBreakStmt, nnkContinueStmt,
-      # nnkBlockStmt, nnkStaticStmt, nnkDiscardStmt, nnkStmtList, nnkImportStmt,
-      # nnkImportExceptStmt, nnkExportStmt, nnkExportExceptStmt, nnkFromStmt,
-      # nnkIncludeStmt, nnkBindStmt, nnkMixinStmt, nnkUsingStmt, nnkCommentStmt,
-      # nnkStmtListExpr, nnkBlockExpr, nnkStmtListType, nnkBlockType, nnkWith, nnkWithout,
-      # nnkTypeOfExpr, nnkObjectTy, nnkTupleTy, nnkTupleClassTy, nnkTypeClassTy,
-      # nnkStaticTy, nnkRecList, nnkRecCase, nnkRecWhen, nnkRefTy, nnkPtrTy, nnkVarTy,
-      # nnkConstTy, nnkMutableTy, nnkDistinctTy, nnkProcTy, nnkIteratorTy, nnkSharedTy,
-      # nnkEnumTy, nnkEnumFieldDef, nnkArglist, nnkPattern, nnkHiddenTryStmt, nnkClosure,
-      # nnkGotoState, nnkState, nnkBreakState, nnkFuncDef, nnkTupleConstr
-
 proc checkReplaceSelfVar(node: NimNode, childIndex: int, varsList, propsList: seq[string]) {.compileTime.} =
   let identName = node[childIndex].strVal
   if varsList.binarySearch(identName) == -1 and propsList.binarySearch(identName) != -1:
@@ -572,11 +543,6 @@ proc genType(obj: ObjectDecl): NimNode {.compileTime.} =
     ))
   else:
     initMethod.body.insert(0, initBody)
-
-  # {.this: self.} for convenience
-  # result.add(newNimNode(nnkPragma).add(newNimNode(nnkExprColonExpr).add(
-  #   ident("this"), ident("self")
-  # )))
 
   # Nim proc defintions
   var decls = newSeqOfCap[NimNode](obj.methods.len)
@@ -742,10 +708,6 @@ N_NOINLINE(void, nimGC_setStackBottom)(void* thestackbottom);
                                  GodotMethodAttributes(), refDec)
     result.add(getAst(registerRefIncDec(classNameLit)))
 
-# {.push warning[Deprecated]: off.}
-# immediate macros are deprecated, but `untyped` doesn't make it immediate,
-# as the warning and the documentation claim.
-
 macro gdobj*(ast: varargs[untyped]): untyped =
   ## Generates Godot type. Self-documenting example:
   ##
@@ -793,4 +755,3 @@ macro gdobj*(ast: varargs[untyped]): untyped =
   let typeDef = parseType(ast)
   result = genType(typeDef)
 
-# {.push warning[Deprecated]: on.}

--- a/godot/nim/godotmacros.nim
+++ b/godot/nim/godotmacros.nim
@@ -454,7 +454,9 @@ proc applySelf(node: NimNode, varsList: ref seq[string], propsList, methodsList:
       if node[0].kind == nnkDotExpr:
         lowIndx = 0
       elif node[0].kind == nnkIdent:
-        checkReplaceSelfMethod(node, 0, methodsList)
+        if node[0].strVal != "procCall":
+          checkReplaceSelfMethod(node, 0, methodsList)
+          lowIndx = 1
       else:
         lowIndx = 1
     of nnkInfix..nnkPostfix, nnkExprColonExpr, nnkObjConstr, nnkCast:
@@ -754,4 +756,5 @@ macro gdobj*(ast: varargs[untyped]): untyped =
   ## that you can find in `Godot API <index.html#modules-godot-api>`_.
   let typeDef = parseType(ast)
   result = genType(typeDef)
+
 

--- a/godot/nim/godotnim.nim
+++ b/godot/nim/godotnim.nim
@@ -345,18 +345,18 @@ proc newRStrLit(s: string): NimNode {.compileTime.} =
 
 macro toGodotName(T: typedesc): untyped =
   if T is GodotString or T is string:
-    newLit("String")
+    newStrLitNode"String"
   elif T is SomeFloat:
-    newLit("float")
+    newStrLitNode"float"
   elif T is SomeUnsignedInt or T is SomeSignedInt:
-    newLit("int")
+    newStrLitNode"int"
   else:
-    let nameStr = (($T.getType()[1][1].symbol).split(':')[0])
+    let nameStr = ((T.getType()[1][1].strVal).split(':')[0])
     case nameStr:
       of "File", "Directory", "Thread", "Mutex", "Semaphore":
-        newLit("_" & nameStr)
+        newStrLitNode("_" & nameStr)
       else:
-        newLit(nameStr)
+        newStrLitNode(nameStr)
 
 macro asCString(s: static[string]): cstring =
   result = newNimNode(nnkCallStrLit).add(
@@ -366,7 +366,7 @@ proc getSingleton*[T: NimGodotObject](): T =
   ## Returns singleton of type ``T``. Normally, this should not be used,
   ## because `godotapigen <godotapigen.html>`_ wraps singleton methods so that
   ## singleton objects don't have to be provided as parameters.
-  const godotName = asCString(toGodotName(T).strVal)
+  const godotName = asCString(toGodotName(T))
   let singleton = getGodotSingleton(godotName)
   if singleton.isNil:
     printError("Tried to get non-existing singleton of type " & $godotName)
@@ -415,7 +415,7 @@ proc newOwnObj[T: NimGodotObject](name: cstring): T =
 
 proc gdnew*[T: NimGodotObject](): T =
   ## Instantiates new object of type ``T``.
-  const godotName = toGodotName(T).strVal
+  const godotName = toGodotName(T)
   const cGodotName = asCString(godotName)
   const objInfo = classRegistryStatic[fnv1Hash(godotName)]
   when objInfo.isNative:
@@ -491,7 +491,7 @@ proc godotTypeInfo*(T: typedesc[NimGodotObject]): GodotTypeInfo {.inline.} =
     variantType: VariantType.Object,
     hint: when isResource(T): GodotPropertyHint.ResourceType
           else: GodotPropertyHint.None,
-    hintStr: toGodotName(T).strVal
+    hintStr: toGodotName(T)
   )
 
 proc toVariant*(self: NimGodotObject): Variant {.inline.} =

--- a/godot/nim/nim.cfg
+++ b/godot/nim/nim.cfg
@@ -1,1 +1,2 @@
 --path:"$projectdir/../"
+-d:userealtimeGC


### PR DESCRIPTION
- Attempt to fix deprecated this:self pragma by injecting self to methods and properties (needs more testing)
- Changed import headers to use / (slash) instead of . (period)
- Fixed object branch in godotapigen.nim
- Fixed deprecated nimNode.ident with nimNode.strVal